### PR TITLE
Generated sample job is empty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
 								<bannedDependencies>
 									<excludes>
 										<exclude>xml-apis:xml-apis</exclude>
+										<exclude>javax.xml.bind:jaxb-api</exclude>
 									</excludes>
 								</bannedDependencies>
 							</rules>
@@ -227,6 +228,10 @@
 				<exclusion>
 					<groupId>xml-apis</groupId>
 					<artifactId>xml-apis</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.xml.bind</groupId>
+					<artifactId>jaxb-api</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/src/main/java/org/pentaho/di/profiling/datacleaner/ModelerHelper.java
+++ b/src/main/java/org/pentaho/di/profiling/datacleaner/ModelerHelper.java
@@ -177,8 +177,7 @@ public class ModelerHelper extends AbstractXulEventHandler implements ISpoonMenu
 
             // Finally, the class to launch
             //
-            final SoftwareVersion editionDetails = SoftwareVersionHelper
-                    .getEditionDetails(dcInstallationFolder);
+            final SoftwareVersion editionDetails = SoftwareVersionHelper.getEditionDetails(dcInstallationFolder);
 
             if (editionDetails != null) {
                 if (editionDetails.getName() == SoftwareVersionHelper.DATACLEANER_COMMUNITY) {
@@ -292,7 +291,7 @@ public class ModelerHelper extends AbstractXulEventHandler implements ISpoonMenu
         final Shell shell = new Shell(display, SWT.DIALOG_TRIM);
         final DataCleanerConfigurationDialog dataCleanerSettingsDialog = new DataCleanerConfigurationDialog(shell,
                 SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
-        
+
         final String dialogResult = dataCleanerSettingsDialog.open();
 
         final String pluginFolderPath = getPluginFolderPath();


### PR DESCRIPTION
Fixes #14. Excluded jaxb-api from the dependencies. 

Instantion of JaxbJobWriter  returned a NPE. 

The whole stacktrace is 

```
[javax.xml.bind.ContextFinder.handleClassCastException(ContextFinder.java:95), javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:167), javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:112), javax.xml.bind.ContextFinder.find(ContextFinder.java:322), javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:412), javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:375), org.datacleaner.job.JaxbJobWriter.<init>(JaxbJobWriter.java:96), org.datacleaner.job.JaxbJobWriter.<init>(JaxbJobWriter.java:104), org.pentaho.di.profiling.datacleaner.ModelerHelper.profileStep(ModelerHelper.java:392), sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method), sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62), sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43), java.lang.reflect.Method.invoke(Method.java:497), org.pentaho.ui.xul.impl.AbstractXulDomContainer.invoke(AbstractXulDomContainer.java:305), org.pentaho.ui.xul.impl.AbstractXulDomContainer.invoke(AbstractXulDomContainer.java:290), org.pentaho.ui.xul.impl.AbstractXulComponent.invoke(AbstractXulComponent.java:157), org.pentaho.ui.xul.impl.AbstractXulComponent.invoke(AbstractXulComponent.java:141), org.pentaho.ui.xul.jface.tags.JfaceMenuitem.access$100(JfaceMenuitem.java:43), org.pentaho.ui.xul.jface.tags.JfaceMenuitem$1.run(JfaceMenuitem.java:106), org.eclipse.jface.action.Action.runWithEvent(Action.java:498), org.eclipse.jface.action.ActionContributionItem.handleWidgetSelection(ActionContributionItem.java:545), org.eclipse.jface.action.ActionContributionItem.access$2(ActionContributionItem.java:490), org.eclipse.jface.action.ActionContributionItem$5.handleEvent(ActionContributionItem.java:402), org.eclipse.swt.widgets.EventTable.sendEvent(Unknown Source), org.eclipse.swt.widgets.Display.sendEvent(Unknown Source), org.eclipse.swt.widgets.Widget.sendEvent(Unknown Source), org.eclipse.swt.widgets.Widget.sendEvent(Unknown Source), org.eclipse.swt.widgets.Widget.sendEvent(Unknown Source), org.eclipse.swt.widgets.Widget.notifyListeners(Unknown Source), org.eclipse.swt.widgets.Display.runDeferredEvents(Unknown Source), org.eclipse.swt.widgets.Display.readAndDispatch(Unknown Source), org.pentaho.di.ui.spoon.Spoon.readAndDispatch(Spoon.java:1319), org.pentaho.di.ui.spoon.Spoon.waitForDispose(Spoon.java:7939), org.pentaho.di.ui.spoon.Spoon.start(Spoon.java:9190), org.pentaho.di.ui.spoon.Spoon.main(Spoon.java:654), sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method), sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62), sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43), java.lang.reflect.Method.invoke(Method.java:497), org.pentaho.commons.launcher.Launcher.main(Launcher.java:92)]
```

![screen shot 2015-09-10 at 11 54 47 am](https://cloud.githubusercontent.com/assets/6339923/9785452/db399ed8-57b2-11e5-8cc3-1d93f9c29f19.png)
