### PR TITLE
Feature/26 make execute job work with the same instance tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.eobjects.datacleaner</groupId>
@@ -6,8 +7,8 @@
 		<version>4.5</version>
 	</parent>
 	<properties>
-		<kettle.version>5.3.0.2</kettle.version>
-		<datacleaner.version>4.5</datacleaner.version>
+		<kettle.version>6.0.1.0-386</kettle.version>
+		<datacleaner.version>4.5.4</datacleaner.version>
 		<mainClass>org.datacleaner.Main</mainClass>
 	</properties>
 	<artifactId>pdi-datacleaner</artifactId>
@@ -273,6 +274,12 @@
 			<groupId>org.eobjects.datacleaner</groupId>
 			<artifactId>DataCleaner-basic-analyzers</artifactId>
 			<version>${datacleaner.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>xml-apis</groupId>
+					<artifactId>xml-apis</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/datacleaner/kettle/jobentry/DataCleanerJobEntryConfiguration.java
+++ b/src/main/java/org/datacleaner/kettle/jobentry/DataCleanerJobEntryConfiguration.java
@@ -2,15 +2,10 @@ package org.datacleaner.kettle.jobentry;
 
 import java.io.Serializable;
 
-import org.datacleaner.kettle.configuration.DataCleanerSpoonConfiguration;
-import org.datacleaner.kettle.configuration.DataCleanerSpoonConfigurationException;
-import org.pentaho.di.profiling.datacleaner.ModelerHelper;
-
 public class DataCleanerJobEntryConfiguration implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 1L;
 
-    private String executableFilename;
     private String jobFilename;
     private DataCleanerOutputType outputType;
     private String outputFilename;
@@ -26,27 +21,6 @@ public class DataCleanerJobEntryConfiguration implements Serializable, Cloneable
 
     public void setJobFilename(String jobFile) {
         this.jobFilename = jobFile;
-    }
-
-    public String getExecutableFilename() {
-        if (executableFilename == null) {
-            try {
-                DataCleanerSpoonConfiguration dcSpoonConfiguration = DataCleanerSpoonConfiguration.load();
-                final String dataCleanerInstallationFolderPath = dcSpoonConfiguration
-                        .getDataCleanerInstallationFolderPath();
-                executableFilename = dataCleanerInstallationFolderPath + "/DataCleaner-console.exe";
-            } catch (DataCleanerSpoonConfigurationException e) {
-                ModelerHelper.showErrorMessage("DataCleaner configuration error",
-                        "DataCleaner configuration not available", e);
-                return null;
-            }
-
-        }
-        return executableFilename;
-    }
-
-    public void setExecutableFilename(String executableFile) {
-        this.executableFilename = executableFile;
     }
 
     public String getOutputFilename() {

--- a/src/main/java/org/datacleaner/kettle/jobentry/DataCleanerJobEntryDialog.java
+++ b/src/main/java/org/datacleaner/kettle/jobentry/DataCleanerJobEntryDialog.java
@@ -17,7 +17,6 @@ import plugin.DataCleanerJobEntry;
 
 public class DataCleanerJobEntryDialog extends AbstractJobEntryDialog implements JobEntryDialogInterface {
 
-    private TextVar executableFilenameField;
     private TextVar jobFilenameField;
     private TextVar additionalArgumentsField;
     private OutputFileSelectionWidget outputFileSelectionWidget;
@@ -29,16 +28,6 @@ public class DataCleanerJobEntryDialog extends AbstractJobEntryDialog implements
 
     @Override
     protected void addConfigurationFields(Group propertiesGroup, int margin, int middle) {
-
-        // Executable field
-        {
-            final Label fieldLabel = new Label(propertiesGroup, SWT.RIGHT);
-            fieldLabel.setLayoutData(WidgetFactory.createGridData());
-            fieldLabel.setText("DataCleaner executable:");
-
-            executableFilenameField = new TextVar(jobMeta, propertiesGroup, SWT.SINGLE | SWT.LEFT | SWT.BORDER);
-            executableFilenameField.setLayoutData(WidgetFactory.createGridData());
-        }
 
         // Job file
         {
@@ -84,7 +73,6 @@ public class DataCleanerJobEntryDialog extends AbstractJobEntryDialog implements
         {
             final DataCleanerJobEntryConfiguration configuration = getConfiguration();
             outputTypeCombo.setValue(configuration.getOutputType());
-            executableFilenameField.setText(configuration.getExecutableFilename());
             jobFilenameField.setText(configuration.getJobFilename());
             outputFileSelectionWidget.setOutputFilename(configuration.getOutputFilename());
             outputFileSelectionWidget.setOutputFileInResult(configuration.isOutputFileInResult());
@@ -95,7 +83,6 @@ public class DataCleanerJobEntryDialog extends AbstractJobEntryDialog implements
     @Override
     public void ok() {
         DataCleanerJobEntryConfiguration configuration = getConfiguration();
-        configuration.setExecutableFilename(executableFilenameField.getText());
         configuration.setJobFilename(jobFilenameField.getText());
         configuration.setOutputFilename(outputFileSelectionWidget.getOutputFilename());
         configuration.setOutputFileInResult(outputFileSelectionWidget.isOutputFileInResult());

--- a/src/main/java/org/datacleaner/kettle/ui/AbstractJobEntryDialog.java
+++ b/src/main/java/org/datacleaner/kettle/ui/AbstractJobEntryDialog.java
@@ -51,7 +51,7 @@ public abstract class AbstractJobEntryDialog extends JobEntryDialog implements J
     protected void initializeShell(Shell shell) {
         String id = PluginRegistry.getInstance().getPluginId(JobEntryPluginType.class, jobMeta);
         if (id != null) {
-            shell.setImage(GUIResource.getInstance().getImagesSteps().get(id));
+            shell.setImage(GUIResource.getInstance().getImagesStepsSmall().get(id));
         }
     }
 

--- a/src/main/java/org/pentaho/di/profiling/datacleaner/DataCleanerKettleFileWriter.java
+++ b/src/main/java/org/pentaho/di/profiling/datacleaner/DataCleanerKettleFileWriter.java
@@ -3,7 +3,7 @@ package org.pentaho.di.profiling.datacleaner;
 import java.io.DataOutputStream;
 import java.util.List;
 
-import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs2.FileObject;
 import org.pentaho.di.core.exception.KettleFileException;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.logging.LogChannelInterface;

--- a/src/main/java/org/pentaho/di/profiling/datacleaner/ModelerHelper.java
+++ b/src/main/java/org/pentaho/di/profiling/datacleaner/ModelerHelper.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs2.FileObject;
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.schema.Column;
 import org.datacleaner.api.InputColumn;

--- a/src/main/java/org/pentaho/di/profiling/datacleaner/ModelerHelper.java
+++ b/src/main/java/org/pentaho/di/profiling/datacleaner/ModelerHelper.java
@@ -64,8 +64,8 @@ import com.google.common.base.Splitter;
 
 public class ModelerHelper extends AbstractXulEventHandler implements ISpoonMenuController {
 
-    private static final String MAIN_CLASS_COMMUNITY = "org.datacleaner.Main";
-    private static final String MAIN_CLASS_ENTERPRISE = "com.hi.datacleaner.Main";
+    public static final String MAIN_CLASS_COMMUNITY = "org.datacleaner.Main";
+    public static final String MAIN_CLASS_ENTERPRISE = "com.hi.datacleaner.Main";
 
     private static final Set<String> ID_COLUMN_TOKENS = new HashSet<>(Arrays.asList("id", "pk", "number", "no", "nr",
             "key"));
@@ -116,7 +116,7 @@ public class ModelerHelper extends AbstractXulEventHandler implements ISpoonMenu
         return "profiler"; //$NON-NLS-1$
     }
 
-    private static DataCleanerSpoonConfiguration getDataCleanerSpoonConfigurationOrShowError() {
+    public static DataCleanerSpoonConfiguration getDataCleanerSpoonConfigurationOrShowError() {
         try {
             DataCleanerSpoonConfiguration result = DataCleanerSpoonConfiguration.load();
             return result;
@@ -241,7 +241,7 @@ public class ModelerHelper extends AbstractXulEventHandler implements ISpoonMenu
         });
     }
 
-    private static String getJarFile(String libPath, final String filename) {
+    public static String getJarFile(String libPath, final String filename) {
         final File directory = new File(libPath);
         assert directory.exists() && directory.isDirectory();
 

--- a/src/main/java/org/pentaho/di/profiling/datacleaner/ProfilerDatabaseExplorerController.java
+++ b/src/main/java/org/pentaho/di/profiling/datacleaner/ProfilerDatabaseExplorerController.java
@@ -4,7 +4,7 @@ import java.io.OutputStream;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs2.FileObject;
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.Schema;

--- a/src/main/java/org/pentaho/di/profiling/datacleaner/ProfilerDatabaseExplorerController.java
+++ b/src/main/java/org/pentaho/di/profiling/datacleaner/ProfilerDatabaseExplorerController.java
@@ -160,7 +160,7 @@ public class ProfilerDatabaseExplorerController extends AbstractXulEventHandler 
                                         jobFileName = KettleVFS.getFilename(jobFile);
                                     }
                                     ModelerHelper.launchDataCleaner(dataCleanerSpoonConfiguration,
-                                            KettleVFS.getFilename(confFile), jobFileName, dbMeta.getName(), null);
+                                            KettleVFS.getFilename(confFile), jobFileName, dbMeta.getName(), null,null,null,null,true);
                                 }
                             }.start();
                         }

--- a/src/main/java/plugin/DataCleanerJobEntry.java
+++ b/src/main/java/plugin/DataCleanerJobEntry.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs2.FileObject;
 import org.datacleaner.kettle.jobentry.DataCleanerJobEntryConfiguration;
 import org.datacleaner.kettle.jobentry.DataCleanerJobEntryDialog;
 import org.datacleaner.kettle.jobentry.DataCleanerOutputType;

--- a/src/main/java/plugin/DataCleanerJobEntry.java
+++ b/src/main/java/plugin/DataCleanerJobEntry.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.vfs2.FileObject;
+import org.datacleaner.kettle.configuration.DataCleanerSpoonConfiguration;
+import org.datacleaner.kettle.configuration.utils.SoftwareVersionHelper;
+import org.datacleaner.kettle.configuration.utils.SoftwareVersionHelper.SoftwareVersion;
 import org.datacleaner.kettle.jobentry.DataCleanerJobEntryConfiguration;
 import org.datacleaner.kettle.jobentry.DataCleanerJobEntryDialog;
 import org.datacleaner.kettle.jobentry.DataCleanerOutputType;
@@ -20,12 +23,15 @@ import org.pentaho.di.core.annotations.JobEntry;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.job.entry.JobEntryBase;
 import org.pentaho.di.job.entry.JobEntryInterface;
+import org.pentaho.di.profiling.datacleaner.ModelerHelper;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
+import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Node;
 
@@ -45,12 +51,28 @@ public class DataCleanerJobEntry extends JobEntryBase implements JobEntryInterfa
     @Override
     public Result execute(Result result, int nr) throws KettleException {
 
-        final List<String> commands = new ArrayList<String>();
-        final String executableFilePath = environmentSubstitute(configuration.getExecutableFilename());
-        final File executableFile = new File(executableFilePath);
-        final String outputFilename = environmentSubstitute(configuration.getOutputFilename());
+        final LogChannelInterface log = Spoon.getInstance().getLog();
 
-        commands.add(executableFilePath);
+        final List<String> commands = new ArrayList<String>();
+        final String outputFilename = environmentSubstitute(configuration.getOutputFilename());
+        final DataCleanerSpoonConfiguration dataCleanerSpoonConfiguration = ModelerHelper
+                .getDataCleanerSpoonConfigurationOrShowError();
+        final String dcInstallationPath = dataCleanerSpoonConfiguration.getDataCleanerInstallationFolderPath()
+                + "/DataCleaner.jar";
+
+        // Assemble the class path for DataCleaner
+        commands.add(System.getProperty("java.home") + "/bin/java");
+        commands.add("-cp");
+        commands.add(environmentSubstitute(dcInstallationPath));
+
+        final SoftwareVersion editionDetails = SoftwareVersionHelper.getEditionDetails(dataCleanerSpoonConfiguration);
+        if (editionDetails != null) {
+            if (editionDetails.getName() == SoftwareVersionHelper.DATACLEANER_COMMUNITY) {
+                commands.add(ModelerHelper.MAIN_CLASS_COMMUNITY);
+            } else {
+                commands.add(ModelerHelper.MAIN_CLASS_ENTERPRISE);
+            }
+        }
         commands.add("-job");
         commands.add(environmentSubstitute(configuration.getJobFilename()));
         commands.add("-ot");
@@ -66,8 +88,16 @@ public class DataCleanerJobEntry extends JobEntryBase implements JobEntryInterfa
             }
         }
 
+        StringBuilder commandString = new StringBuilder();
+        for (String cmd : commands) {
+            commandString.append(cmd).append(" ");
+        }
+
+        log.logBasic("DataCleaner launch commands : " + commandString);
+
         final ProcessBuilder processBuilder = new ProcessBuilder(commands);
-        final File dataCleanerDirectory = executableFile.getParentFile();
+        final File dataCleanerDirectory = new File(dataCleanerSpoonConfiguration
+                .getDataCleanerInstallationFolderPath());
         processBuilder.directory(dataCleanerDirectory);
         processBuilder.redirectErrorStream(true);
 
@@ -94,14 +124,14 @@ public class DataCleanerJobEntry extends JobEntryBase implements JobEntryInterfa
             if (configuration.isOutputFileInResult()) {
                 File outputFile = new File(outputFilename);
                 if (!outputFile.exists()) {
-                    outputFile = new File(dataCleanerDirectory, outputFilename);
+                    outputFile = new File(dataCleanerSpoonConfiguration.getPluginFolderPath(), outputFilename);
                 }
 
                 if (outputFile.exists()) {
                     final Map<String, ResultFile> files = new ConcurrentHashMap<String, ResultFile>();
                     final FileObject fileObject = KettleVFS.getFileObject(outputFile.getCanonicalPath(), this);
-                    final ResultFile resultFile = new ResultFile(ResultFile.FILE_TYPE_GENERAL, fileObject,
-                            parentJob.getJobname(), toString());
+                    final ResultFile resultFile = new ResultFile(ResultFile.FILE_TYPE_GENERAL, fileObject, parentJob
+                            .getJobname(), toString());
                     files.put(outputFilename, resultFile);
                     result.setResultFiles(files);
                 }
@@ -135,15 +165,13 @@ public class DataCleanerJobEntry extends JobEntryBase implements JobEntryInterfa
         final StringBuilder retval = new StringBuilder();
 
         retval.append(super.getXML());
-        retval.append("      ")
-                .append(XMLHandler.addTagValue("executable_file", configuration.getExecutableFilename()));
         retval.append("      ").append(XMLHandler.addTagValue("job_file", configuration.getJobFilename()));
         retval.append("      ").append(XMLHandler.addTagValue("output_file", configuration.getOutputFilename()));
         retval.append("      ").append(XMLHandler.addTagValue("output_type", configuration.getOutputType().toString()));
-        retval.append("      ").append(
-                XMLHandler.addTagValue("output_file_in_result", configuration.isOutputFileInResult()));
-        retval.append("      ").append(
-                XMLHandler.addTagValue("additional_arguments", configuration.getAdditionalArguments()));
+        retval.append("      ").append(XMLHandler.addTagValue("output_file_in_result", configuration
+                .isOutputFileInResult()));
+        retval.append("      ").append(XMLHandler.addTagValue("additional_arguments", configuration
+                .getAdditionalArguments()));
 
         return retval.toString();
     }
@@ -153,11 +181,10 @@ public class DataCleanerJobEntry extends JobEntryBase implements JobEntryInterfa
         try {
             super.loadXML(entrynode, databases, slaveServers);
 
-            configuration.setExecutableFilename(XMLHandler.getTagValue(entrynode, "executable_file"));
             configuration.setJobFilename(XMLHandler.getTagValue(entrynode, "job_file"));
             configuration.setOutputFilename(XMLHandler.getTagValue(entrynode, "output_file"));
-            configuration
-                    .setOutputType(DataCleanerOutputType.valueOf(XMLHandler.getTagValue(entrynode, "output_type")));
+            configuration.setOutputType(DataCleanerOutputType.valueOf(XMLHandler.getTagValue(entrynode,
+                    "output_type")));
             final String outputFileInResult = XMLHandler.getTagValue(entrynode, "output_file_in_result");
             if ("false".equalsIgnoreCase(outputFileInResult)) {
                 configuration.setOutputFileInResult(false);
@@ -174,12 +201,12 @@ public class DataCleanerJobEntry extends JobEntryBase implements JobEntryInterfa
     public void saveRep(Repository rep, IMetaStore metaStore, ObjectId id_job) throws KettleException {
         super.saveRep(rep, metaStore, id_job);
 
-        rep.saveJobEntryAttribute(id_job, getObjectId(), "executable_file", configuration.getExecutableFilename());
         rep.saveJobEntryAttribute(id_job, getObjectId(), "job_file", configuration.getJobFilename());
         rep.saveJobEntryAttribute(id_job, getObjectId(), "output_file", configuration.getOutputFilename());
         rep.saveJobEntryAttribute(id_job, getObjectId(), "output_type", configuration.getOutputType().toString());
         rep.saveJobEntryAttribute(id_job, getObjectId(), "output_file_in_result", configuration.isOutputFileInResult());
-        rep.saveJobEntryAttribute(id_job, getObjectId(), "additional_arguments", configuration.getAdditionalArguments());
+        rep.saveJobEntryAttribute(id_job, getObjectId(), "additional_arguments", configuration
+                .getAdditionalArguments());
     }
 
     @Override
@@ -187,13 +214,12 @@ public class DataCleanerJobEntry extends JobEntryBase implements JobEntryInterfa
             List<SlaveServer> slaveServers) throws KettleException {
         super.loadRep(rep, metaStore, id_jobentry, databases, slaveServers);
 
-        configuration.setExecutableFilename(rep.getJobEntryAttributeString(id_jobentry, "executable_file"));
         configuration.setJobFilename(rep.getJobEntryAttributeString(id_jobentry, "job_file"));
         configuration.setOutputFilename(rep.getJobEntryAttributeString(id_jobentry, "output_file"));
         configuration.setOutputType(DataCleanerOutputType.valueOf(rep.getJobEntryAttributeString(id_jobentry,
                 "output_type")));
-        configuration
-                .setOutputFileInResult(rep.getJobEntryAttributeBoolean(id_jobentry, "output_file_in_result", true));
+        configuration.setOutputFileInResult(rep.getJobEntryAttributeBoolean(id_jobentry, "output_file_in_result",
+                true));
         configuration.setAdditionalArguments(rep.getJobEntryAttributeString(id_jobentry, "additional_arguments"));
     }
 }


### PR DESCRIPTION
Fixes #26 and #20  

The DCJobEntry  has been changed to use the centrally configured DC instance. 

This branch is build upon bug/27-make-pdi-work-for-6.0 because I wanted to test the fix in the latest Pentaho versions. So review/merge after merging https://github.com/datacleaner/pdi-datacleaner/pull/28. 

Versions tested:
- pdi-ce-6.0.0.0-353
- pdi-ce-6.0.1.0-386
